### PR TITLE
drop ES 0.9x support and some more improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,35 @@
 elasticsearch-collectd-plugin
 =====================
 
-A [ElasticSearch](http://elasticsearch.org) plugin for [collectd](http://collectd.org) using collectd's [Python plugin](http://collectd.org/documentation/manpages/collectd-python.5.shtml).
+An [ElasticSearch](http://elasticsearch.org) plugin for [collectd](http://collectd.org) using collectd's [Python plugin](http://collectd.org/documentation/manpages/collectd-python.5.shtml).
 
-Common Stats :
- * Docs (Total docs & Deleted docs)
- * Store size 
- * Indexing (Total, time, Total delete, Delete time)
- * Get (Total, Time, Exists otal, Exists time, Missing total, Missing Time)
- * Search (Total query, total time, total fetch, total fetch time)
- * JVM Memory (Heap commited, Heap Used, Non heap commited, Non heap used)
- * JVM Threads (Count & Peak)
- * JVM GC (Time & Count)
- * Transport stats (Server open, RX count, RX size, TX count, TX size)
- * HTTP Stats (Current open & Total open)
-
-ES 1.0 Stats :
- * Cache (Field Eviction, Field Size, Filter evictions, Filter size)
- * JVM Collectors
- * FLush (Total count, total time)
- * Merges (Current count, current docs, current size, Merge total size, docs a time)
+Node stats :
+ * Docs (total docs & deleted docs)
+ * Store size
+ * Indexing (total, time, total delete, delete time)
+ * Get (total, time, exists total, exists time, missing total, missing time)
+ * Search (total query, total time, total fetch, total fetch time)
+ * JVM memory (heap commited, heap Used, non heap commited, non heap used)
+ * JVM threads (count & peak)
+ * JVM GC (time & count)
+ * Transport stats (server open, RX count, RX size, TX count, TX size)
+ * HTTP stats (current open & total open)
+ * OS stats (CPU percent, file descriptors)
+ * Thread pool stats (generic, index, get, snapshot, merge, optimize, bulk, warmer, flush, search, refresh)
+ * Cache (field eviction, field size, filter evictions, filter size)
+ * JVM collectors
+ * FLush (total count, total time)
+ * Merges (current count, current docs, current size, merge total size, docs a time)
  * Refresh (Total & Time)
+
+Index stats:
+ * Transaction log (size, number of operations)
+ * Most of the common stats per index and per primary vs. total.
+
+Cluster stats:
+ * Shard stats (active, initializing, relocating, unassigned, primaries)
+ * Nodes (total, data nodes)
+
 
 Install
 -------
@@ -31,9 +40,10 @@ Install
 Configuration
 -------------
  * See elasticsearch.conf
- * Set the version (0.9 or 1.0), default is 1.0
+ * The plugin will automatically determine the version of elasticsearch.
+ * Per index and cluster stats can be disabled if needed. They are enabled by default.
 
 Requirements
 ------------
  * collectd 4.9+
- * Elasticsearch 0.9.x or 1.X
+ * Elasticsearch 1.x or later.

--- a/elasticsearch.conf
+++ b/elasticsearch.conf
@@ -9,7 +9,6 @@
 
     <Module "elasticsearch_collectd">
         Verbose false
-        Version "1.7.0"
         Cluster "elasticsearch"
         Indexes ["_all"]
         EnableIndexStats true


### PR DESCRIPTION
Most people should already be on the 1.x release and 0.9x metrics aren't
property working. This simplifies the script since 1.x stats are all
backward compatible.

This commit also makes version detection automatic and fixes an issue
with cluster statistics.

Updated the README file while in there.
