### PR TITLE
fix document count to be a gauge instead of a counter

### DIFF
--- a/elasticsearch_collectd.py
+++ b/elasticsearch_collectd.py
@@ -213,8 +213,8 @@ INDEX_STATS = {
 
     # PRIMARIES
     # DOCS
-    "indices[index={index_name}].primaries.docs.count": Stat("counter", "primaries.docs.count"),
-    "indices[index={index_name}].primaries.docs.deleted": Stat("counter", "primaries.docs.deleted"),
+    "indices[index={index_name}].primaries.docs.count": Stat("gauge", "primaries.docs.count"),
+    "indices[index={index_name}].primaries.docs.deleted": Stat("gauge", "primaries.docs.deleted"),
 
     # STORE
     "indices[index={index_name}].primaries.store.size_in_bytes": Stat("bytes", "primaries.store.size_in_bytes"),


### PR DESCRIPTION
total and deleted document counts should be of type gauge since merges
will likely cause them to decrease.
