### PR TITLE
and more counters + consistency/types cleanups

### DIFF
--- a/elasticsearch_collectd.py
+++ b/elasticsearch_collectd.py
@@ -52,9 +52,9 @@ NODE_STATS = {
 
     # CACHE
     'indices.cache.field.eviction': Stat("counter", "nodes.%s.indices.fielddata.evictions"),
-    'indices.cache.field.size': Stat("bytes", "nodes.%s.indices.fielddata.memory_size_in_bytes"),
+    'indices.cache.field.size': Stat("gauge", "nodes.%s.indices.fielddata.memory_size_in_bytes"),
     'indices.cache.filter.evictions': Stat("counter", "nodes.%s.indices.filter_cache.evictions"),
-    'indices.cache.filter.size': Stat("bytes", "nodes.%s.indices.filter_cache.memory_size_in_bytes"),
+    'indices.cache.filter.size': Stat("gauge", "nodes.%s.indices.filter_cache.memory_size_in_bytes"),
 
     # GC
     'jvm.gc.time': Stat("counter", "nodes.%s.jvm.gc.collectors.young.collection_time_in_millis"),
@@ -69,7 +69,7 @@ NODE_STATS = {
     # MERGES
     'indices.merges.current': Stat("gauge", "nodes.%s.indices.merges.current"),
     'indices.merges.current-docs': Stat("gauge", "nodes.%s.indices.merges.current_docs"),
-    'indices.merges.current-size': Stat("bytes", "nodes.%s.indices.merges.current_size_in_bytes"),
+    'indices.merges.current-size': Stat("gauge", "nodes.%s.indices.merges.current_size_in_bytes"),
     'indices.merges.total': Stat("counter", "nodes.%s.indices.merges.total"),
     'indices.merges.total-docs': Stat("gauge", "nodes.%s.indices.merges.total_docs"),
     'indices.merges.total-size': Stat("counter", "nodes.%s.indices.merges.total_size_in_bytes"),
@@ -81,14 +81,14 @@ NODE_STATS = {
 
     # SEGMENTS
     'indices.segments.count': Stat("gauge", "nodes.%s.indices.segments.count"),
-    'indices.segments.size': Stat("bytes", "nodes.%s.indices.segments.memory_in_bytes"),
+    'indices.segments.size': Stat("gauge", "nodes.%s.indices.segments.memory_in_bytes"),
 
     # DOCS
     'indices.docs.count': Stat("gauge", "nodes.%s.indices.docs.count"),
     'indices.docs.deleted': Stat("gauge", "nodes.%s.indices.docs.deleted"),
 
     # STORE
-    'indices.store.size': Stat("bytes", "nodes.%s.indices.store.size_in_bytes"),
+    'indices.store.size': Stat("gauge", "nodes.%s.indices.store.size_in_bytes"),
 
     # INDEXING
     'indices.indexing.index-total': Stat("counter", "nodes.%s.indices.indexing.index_total"),
@@ -117,11 +117,11 @@ NODE_STATS = {
 
     # JVM METRICS #
     # MEM
-    'jvm.mem.heap-committed': Stat("bytes", "nodes.%s.jvm.mem.heap_committed_in_bytes"),
-    'jvm.mem.heap-used': Stat("bytes", "nodes.%s.jvm.mem.heap_used_in_bytes"),
+    'jvm.mem.heap-committed': Stat("gauge", "nodes.%s.jvm.mem.heap_committed_in_bytes"),
+    'jvm.mem.heap-used': Stat("gauge", "nodes.%s.jvm.mem.heap_used_in_bytes"),
     'jvm.mem.heap-used-percent': Stat("percent", "nodes.%s.jvm.mem.heap_used_percent"),
-    'jvm.mem.non-heap-committed': Stat("bytes", "nodes.%s.jvm.mem.non_heap_committed_in_bytes"),
-    'jvm.mem.non-heap-used': Stat("bytes", "nodes.%s.jvm.mem.non_heap_used_in_bytes"),
+    'jvm.mem.non-heap-committed': Stat("gauge", "nodes.%s.jvm.mem.non_heap_committed_in_bytes"),
+    'jvm.mem.non-heap-used': Stat("gauge", "nodes.%s.jvm.mem.non_heap_used_in_bytes"),
 
     # THREADS
     'jvm.threads.count': Stat("gauge", "nodes.%s.jvm.threads.count"),
@@ -146,104 +146,104 @@ NODE_STATS = {
 # ElasticSearch 1.3.0
 INDEX_STATS_ES_1_3 = {
     # SEGMENTS
-    "indices[index={index_name}].primaries.segments.index_writer_memory_in_bytes": Stat("bytes", "primaries.segments.index_writer_memory_in_bytes"),
-    "indices[index={index_name}].primaries.segments.version_map_memory_in_bytes": Stat("bytes", "primaries.segments.version_map_memory_in_bytes"),
+    "indices[index={index_name}].primaries.segments.index-writer-memory": Stat("gauge", "primaries.segments.index_writer_memory_in_bytes"),
+    "indices[index={index_name}].primaries.segments.version-map-memory": Stat("gauge", "primaries.segments.version_map_memory_in_bytes"),
 }
 
 # ElasticSearch 1.1.0
 INDEX_STATS_ES_1_1 = {
     # SUGGEST
     "indices[index={index_name}].primaries.suggest.total": Stat("counter", "primaries.suggest.total"),
-    "indices[index={index_name}].primaries.suggest.time_in_millis": Stat("counter", "primaries.suggest.time_in_millis"),
+    "indices[index={index_name}].primaries.suggest.time": Stat("counter", "primaries.suggest.time_in_millis"),
     "indices[index={index_name}].primaries.suggest.current": Stat("gauge", "primaries.suggest.current"),
 }
 
 # ElasticSearch 1.0.0
 INDEX_STATS = {
+    # PRIMARIES
     # TRANSLOG
-    "indices[index={index_name}].primaries.translog.size_in_bytes": Stat("bytes", "primaries.translog.size_in_bytes"),
+    "indices[index={index_name}].primaries.translog.size": Stat("gauge", "primaries.translog.size_in_bytes"),
     "indices[index={index_name}].primaries.translog.operations": Stat("counter", "primaries.translog.operations"),
 
     # SEGMENTS
-    "indices[index={index_name}].primaries.segments.memory_in_bytes": Stat("bytes", "primaries.segments.memory_in_bytes"),
+    "indices[index={index_name}].primaries.segments.memory": Stat("gauge", "primaries.segments.memory_in_bytes"),
     "indices[index={index_name}].primaries.segments.count": Stat("counter", "primaries.segments.count"),
 
     # ID_CACHE
-    "indices[index={index_name}].primaries.id_cache.memory_size_in_bytes": Stat("bytes", "primaries.id_cache.memory_size_in_bytes"),
+    "indices[index={index_name}].primaries.id-cache.memory-size": Stat("gauge", "primaries.id_cache.memory_size_in_bytes"),
 
     # FLUSH
     "indices[index={index_name}].primaries.flush.total": Stat("counter", "primaries.flush.total"),
-    "indices[index={index_name}].primaries.flush.total_time_in_millis": Stat("counter", "primaries.flush.total_time_in_millis"),
+    "indices[index={index_name}].primaries.flush.total-time": Stat("counter", "primaries.flush.total_time_in_millis"),
 
     # WARMER
-    "indices[index={index_name}].primaries.warmer.total.primaries.warmer.total_time_in_millis": Stat("counter", "primaries.warmer.total_time_in_millis"),
+    "indices[index={index_name}].primaries.warmer.total.primaries.warmer.total-time": Stat("counter", "primaries.warmer.total_time_in_millis"),
     "indices[index={index_name}].primaries.warmer.total": Stat("counter", "primaries.warmer.total"),
     "indices[index={index_name}].primaries.warmer.current": Stat("gauge", "primaries.warmer.current"),
 
     # FIELDDATA
-    "indices[index={index_name}].primaries.fielddata.memory_size_in_bytes": Stat("bytes", "primaries.fielddata.memory_size_in_bytes"),
+    "indices[index={index_name}].primaries.fielddata.memory-size": Stat("gauge", "primaries.fielddata.memory_size_in_bytes"),
     "indices[index={index_name}].primaries.fielddata.evictions": Stat("counter", "primaries.fielddata.evictions"),
 
     # REFRESH
-    "indices[index={index_name}].primaries.refresh.total_time_in_millis": Stat("counter", "primaries.refresh.total_time_in_millis"),
+    "indices[index={index_name}].primaries.refresh.total-time": Stat("counter", "primaries.refresh.total_time_in_millis"),
     "indices[index={index_name}].primaries.refresh.total": Stat("counter", "primaries.refresh.total"),
 
     # MERGES
-    "indices[index={index_name}].primaries.merges.total_docs": Stat("counter", "primaries.merges.total_docs"),
-    "indices[index={index_name}].primaries.merges.total_size_in_bytes": Stat("bytes", "primaries.merges.total_size_in_bytes"),
+    "indices[index={index_name}].primaries.merges.total-docs": Stat("counter", "primaries.merges.total_docs"),
+    "indices[index={index_name}].primaries.merges.total-size": Stat("bytes", "primaries.merges.total_size_in_bytes"),
     "indices[index={index_name}].primaries.merges.current": Stat("gauge", "primaries.merges.current"),
     "indices[index={index_name}].primaries.merges.total": Stat("counter", "primaries.merges.total"),
-    "indices[index={index_name}].primaries.merges.current_docs": Stat("gauge", "primaries.merges.current_docs"),
-    "indices[index={index_name}].primaries.merges.total_time_in_millis": Stat("counter", "primaries.merges.total_time_in_millis"),
-    "indices[index={index_name}].primaries.merges.current_size_in_bytes": Stat("bytes", "primaries.merges.current_size_in_bytes"),
+    "indices[index={index_name}].primaries.merges.current-docs": Stat("gauge", "primaries.merges.current_docs"),
+    "indices[index={index_name}].primaries.merges.total-time": Stat("counter", "primaries.merges.total_time_in_millis"),
+    "indices[index={index_name}].primaries.merges.current-size": Stat("gauge", "primaries.merges.current_size_in_bytes"),
 
     # COMPELTION
-    "indices[index={index_name}].primaries.completion.size_in_bytes": Stat("bytes", "primaries.completion.size_in_bytes"),
+    "indices[index={index_name}].primaries.completion.size": Stat("gauge", "primaries.completion.size_in_bytes"),
 
     # PERCOLATE
     "indices[index={index_name}].primaries.percolate.total": Stat("counter", "primaries.percolate.total"),
-    "indices[index={index_name}].primaries.percolate.memory_size_in_bytes": Stat("bytes", "primaries.percolate.memory_size_in_bytes"),
+    "indices[index={index_name}].primaries.percolate.memory-size": Stat("gauge", "primaries.percolate.memory_size_in_bytes"),
     "indices[index={index_name}].primaries.percolate.queries": Stat("counter", "primaries.percolate.queries"),
-    "indices[index={index_name}].primaries.percolate.time_in_millis": Stat("counter", "primaries.percolate.time_in_millis"),
+    "indices[index={index_name}].primaries.percolate.time": Stat("counter", "primaries.percolate.time_in_millis"),
     "indices[index={index_name}].primaries.percolate.current": Stat("gauge", "primaries.percolate.current"),
 
     # FILTER_CACHE
-    "indices[index={index_name}].primaries.filter_cache.evictions": Stat("counter", "primaries.filter_cache.evictions"),
-    "indices[index={index_name}].primaries.filter_cache.memory_size_in_bytes": Stat("bytes", "primaries.filter_cache.memory_size_in_bytes"),
+    "indices[index={index_name}].primaries.filter-cache.evictions": Stat("counter", "primaries.filter_cache.evictions"),
+    "indices[index={index_name}].primaries.filter-cache.memory-size": Stat("gauge", "primaries.filter_cache.memory_size_in_bytes"),
 
-    # PRIMARIES
     # DOCS
     "indices[index={index_name}].primaries.docs.count": Stat("gauge", "primaries.docs.count"),
     "indices[index={index_name}].primaries.docs.deleted": Stat("gauge", "primaries.docs.deleted"),
 
     # STORE
-    "indices[index={index_name}].primaries.store.size_in_bytes": Stat("bytes", "primaries.store.size_in_bytes"),
-    "indices[index={index_name}].primaries.store.throttle_time_in_millis": Stat("counter", "primaries.store.throttle_time_in_millis"),
+    "indices[index={index_name}].primaries.store.size": Stat("gauge", "primaries.store.size_in_bytes"),
+    "indices[index={index_name}].primaries.store.throttle-time": Stat("counter", "primaries.store.throttle_time_in_millis"),
 
     # INDEXING
-    "indices[index={index_name}].primaries.indexing.index_total": Stat("counter", "primaries.indexing.index_total"),
-    "indices[index={index_name}].primaries.indexing.index_time_in_millis": Stat("counter", "primaries.indexing.index_time_in_millis"),
-    "indices[index={index_name}].primaries.indexing.index_current": Stat("gauge", "primaries.indexing.index_current"),
-    "indices[index={index_name}].primaries.indexing.delete_total": Stat("counter", "primaries.indexing.delete_total"),
-    "indices[index={index_name}].primaries.indexing.delete_time_in_millis": Stat("counter", "primaries.indexing.delete_time_in_millis"),
-    "indices[index={index_name}].primaries.indexing.delete_current": Stat("gauge", "primaries.indexing.delete_current"),
+    "indices[index={index_name}].primaries.indexing.index-total": Stat("counter", "primaries.indexing.index_total"),
+    "indices[index={index_name}].primaries.indexing.index-time": Stat("counter", "primaries.indexing.index_time_in_millis"),
+    "indices[index={index_name}].primaries.indexing.index-current": Stat("gauge", "primaries.indexing.index_current"),
+    "indices[index={index_name}].primaries.indexing.delete-total": Stat("counter", "primaries.indexing.delete_total"),
+    "indices[index={index_name}].primaries.indexing.delete-time": Stat("counter", "primaries.indexing.delete_time_in_millis"),
+    "indices[index={index_name}].primaries.indexing.delete-current": Stat("gauge", "primaries.indexing.delete_current"),
 
     # GET
-    "indices[index={index_name}].primaries.get.time_in_millis": Stat("counter", "primaries.get.time_in_millis"),
-    "indices[index={index_name}].primaries.get.exists_total": Stat("counter", "primaries.get.exists_total"),
-    "indices[index={index_name}].primaries.get.exists_time_in_millis": Stat("counter", "primaries.get.exists_time_in_millis"),
-    "indices[index={index_name}].primaries.get.missing_total": Stat("counter", "primaries.get.missing_total"),
-    "indices[index={index_name}].primaries.get.missing_time_in_millis": Stat("counter", "primaries.get.missing_time_in_millis"),
+    "indices[index={index_name}].primaries.get.time": Stat("counter", "primaries.get.time_in_millis"),
+    "indices[index={index_name}].primaries.get.exists-total": Stat("counter", "primaries.get.exists_total"),
+    "indices[index={index_name}].primaries.get.exists-time": Stat("counter", "primaries.get.exists_time_in_millis"),
+    "indices[index={index_name}].primaries.get.missing-total": Stat("counter", "primaries.get.missing_total"),
+    "indices[index={index_name}].primaries.get.missing-time": Stat("counter", "primaries.get.missing_time_in_millis"),
     "indices[index={index_name}].primaries.get.current": Stat("gauge", "primaries.get.current"),
 
     # SEARCH
-    "indices[index={index_name}].primaries.search.open_contexts": Stat("gauge", "primaries.search.open_contexts"),
-    "indices[index={index_name}].primaries.search.query_total": Stat("counter", "primaries.search.query_total"),
-    "indices[index={index_name}].primaries.search.query_time_in_millis": Stat("counter", "primaries.search.query_time_in_millis"),
-    "indices[index={index_name}].primaries.search.query_current": Stat("gauge", "primaries.search.query_current"),
-    "indices[index={index_name}].primaries.search.fetch_total": Stat("counter", "primaries.search.fetch_total"),
-    "indices[index={index_name}].primaries.search.fetch_time_in_millis": Stat("counter", "primaries.search.fetch_time_in_millis"),
-    "indices[index={index_name}].primaries.search.fetch_current": Stat("gauge", "primaries.search.fetch_current"),
+    "indices[index={index_name}].primaries.search.open-contexts": Stat("gauge", "primaries.search.open_contexts"),
+    "indices[index={index_name}].primaries.search.query-total": Stat("counter", "primaries.search.query_total"),
+    "indices[index={index_name}].primaries.search.query-time": Stat("counter", "primaries.search.query_time_in_millis"),
+    "indices[index={index_name}].primaries.search.query-current": Stat("gauge", "primaries.search.query_current"),
+    "indices[index={index_name}].primaries.search.fetch-total": Stat("counter", "primaries.search.fetch_total"),
+    "indices[index={index_name}].primaries.search.fetch-time": Stat("counter", "primaries.search.fetch_time_in_millis"),
+    "indices[index={index_name}].primaries.search.fetch-current": Stat("gauge", "primaries.search.fetch_current"),
 
     ## TOTAL ##
     # DOCS
@@ -251,43 +251,61 @@ INDEX_STATS = {
     "indices[index={index_name}].total.docs.deleted": Stat("gauge", "total.docs.deleted"),
 
     # STORE
-    "indices[index={index_name}].total.store.size_in_bytes": Stat("gauge", "total.store.size_in_bytes"),
-    "indices[index={index_name}].total.store.throttle_time_in_millis": Stat("counter", "total.store.throttle_time_in_millis"),
+    "indices[index={index_name}].total.store.size": Stat("gauge", "total.store.size_in_bytes"),
+    "indices[index={index_name}].total.store.throttle-time": Stat("counter", "total.store.throttle_time_in_millis"),
 
     # INDEXING
-    "indices[index={index_name}].total.indexing.index_total": Stat("counter", "total.indexing.index_total"),
-    "indices[index={index_name}].total.indexing.index_time_in_millis": Stat("counter", "total.indexing.index_time_in_millis"),
-    "indices[index={index_name}].total.indexing.index_current": Stat("gauge", "total.indexing.index_current"),
-    "indices[index={index_name}].total.indexing.delete_total": Stat("counter", "total.indexing.delete_total"),
-    "indices[index={index_name}].total.indexing.delete_time_in_millis": Stat("counter", "total.indexing.delete_time_in_millis"),
-    "indices[index={index_name}].total.indexing.delete_current": Stat("gauge", "total.indexing.delete_current"),
+    "indices[index={index_name}].total.indexing.index-total": Stat("counter", "total.indexing.index_total"),
+    "indices[index={index_name}].total.indexing.index-time": Stat("counter", "total.indexing.index_time_in_millis"),
+    "indices[index={index_name}].total.indexing.index-current": Stat("gauge", "total.indexing.index_current"),
+    "indices[index={index_name}].total.indexing.delete-total": Stat("counter", "total.indexing.delete_total"),
+    "indices[index={index_name}].total.indexing.delete-time": Stat("counter", "total.indexing.delete_time_in_millis"),
+    "indices[index={index_name}].total.indexing.delete-current": Stat("gauge", "total.indexing.delete_current"),
 
     # GET
     "indices[index={index_name}].total.get.total": Stat("counter", "total.get.total"),
-    "indices[index={index_name}].total.get.time_in_millis": Stat("counter", "total.get.time_in_millis"),
-    "indices[index={index_name}].total.get.exists_total": Stat("counter", "total.get.exists_total"),
-    "indices[index={index_name}].total.get.exists_time_in_millis": Stat("counter", "total.get.exists_time_in_millis"),
-    "indices[index={index_name}].total.get.missing_total": Stat("counter", "total.get.missing_total"),
-    "indices[index={index_name}].total.get.missing_time_in_millis": Stat("counter", "total.get.missing_time_in_millis"),
+    "indices[index={index_name}].total.get.time": Stat("counter", "total.get.time_in_millis"),
+    "indices[index={index_name}].total.get.exists-total": Stat("counter", "total.get.exists_total"),
+    "indices[index={index_name}].total.get.exists-time": Stat("counter", "total.get.exists_time_in_millis"),
+    "indices[index={index_name}].total.get.missing-total": Stat("counter", "total.get.missing_total"),
+    "indices[index={index_name}].total.get.missing-time": Stat("counter", "total.get.missing_time_in_millis"),
     "indices[index={index_name}].total.get.current": Stat("gauge", "total.get.current"),
 
     # SEARCH
-    "indices[index={index_name}].total.search.open_contexts": Stat("gauge", "total.search.open_contexts"),
-    "indices[index={index_name}].total.search.query_total": Stat("counter", "total.search.query_total"),
-    "indices[index={index_name}].total.search.query_time_in_millis": Stat("counter", "total.search.query_time_in_millis"),
-    "indices[index={index_name}].total.search.query_current": Stat("gauge", "total.search.query_current"),
-    "indices[index={index_name}].total.search.fetch_total": Stat("counter", "total.search.fetch_total"),
+    "indices[index={index_name}].total.search.open-contexts": Stat("gauge", "total.search.open_contexts"),
+    "indices[index={index_name}].total.search.query-total": Stat("counter", "total.search.query_total"),
+    "indices[index={index_name}].total.search.query-time": Stat("counter", "total.search.query_time_in_millis"),
+    "indices[index={index_name}].total.search.query-current": Stat("gauge", "total.search.query_current"),
+    "indices[index={index_name}].total.search.fetch-total": Stat("counter", "total.search.fetch_total"),
+
+    # MERGES
+    "indices[index={index_name}].total.merges.total-docs": Stat("counter", "total.merges.total_docs"),
+    "indices[index={index_name}].total.merges.total-size": Stat("bytes", "total.merges.total_size_in_bytes"),
+    "indices[index={index_name}].total.merges.current": Stat("gauge", "total.merges.current"),
+    "indices[index={index_name}].total.merges.total": Stat("counter", "total.merges.total"),
+    "indices[index={index_name}].total.merges.current-docs": Stat("gauge", "total.merges.current_docs"),
+    "indices[index={index_name}].total.merges.total-time": Stat("counter", "total.merges.total_time_in_millis"),
+    "indices[index={index_name}].total.merges.current-size": Stat("gauge", "total.merges.current_size_in_bytes"),
+
+    # FILTER_CACHE
+    "indices[index={index_name}].total.filter-cache.evictions": Stat("counter", "total.filter_cache.evictions"),
+    "indices[index={index_name}].total.filter-cache.memory-size": Stat("gauge", "total.filter_cache.memory_size_in_bytes"),
+
+    # FIELDDATA
+    "indices[index={index_name}].total.fielddata.memory-size": Stat("gauge", "total.fielddata.memory_size_in_bytes"),
+    "indices[index={index_name}].total.fielddata.evictions": Stat("counter", "total.fielddata.evictions"),
+
 }
 
 # ElasticSearch cluster stats (1.0.0 and later)
 CLUSTER_STATS = {
-    'cluster.active_primary_shards': Stat("gauge", "active_primary_shards"),
-    'cluster.active_shards': Stat("gauge", "active_shards"),
-    'cluster.initializing_shards': Stat("gauge", "initializing_shards"),
-    'cluster.number_of_data_nodes': Stat("gauge", "number_of_data_nodes"),
-    'cluster.number_of_nodes': Stat("gauge", "number_of_nodes"),
-    'cluster.relocating_shards': Stat("gauge", "relocating_shards"),
-    'cluster.unassigned_shards': Stat("gauge", "unassigned_shards"),
+    'cluster.active-primary-shards': Stat("gauge", "active_primary_shards"),
+    'cluster.active-shards': Stat("gauge", "active_shards"),
+    'cluster.initializing-shards': Stat("gauge", "initializing_shards"),
+    'cluster.number-of-data_nodes': Stat("gauge", "number_of_data_nodes"),
+    'cluster.number-of-nodes': Stat("gauge", "number_of_nodes"),
+    'cluster.relocating-shards': Stat("gauge", "relocating_shards"),
+    'cluster.unassigned-shards': Stat("gauge", "unassigned_shards"),
     'cluster.status': Stat("gauge", "status"),
 }
 


### PR DESCRIPTION
- add per index merge, filter cache and field data statistics
- make collectd metric names consistent with the counters that have been
  there when we forked the repo (replace '_' with '-' and drop units). I'm
  not too fond of doing this (I would have preferred sticking with
  elasticsearch's naming), but it makes finding those metrics consistent
  regardless of whether you are looking for per node, per index (primaries
  vs total) or per cluster statistics.
- update bytes to be gauges since bytes are sent as counters by collectd
  and most of the time it's just a gauge. There are a couple of bytes that
  I left unchanged because those were really counters.
