### PR TITLE
Get default ES_CLUSTER from elastic search URL

### DIFF
--- a/elasticsearch_collectd.py
+++ b/elasticsearch_collectd.py
@@ -22,16 +22,7 @@ PREFIX = "elasticsearch"
 ES_HOST = "localhost"
 ES_PORT = 9200
 ES_VERSION = None
-ES_CLUSTER = set_default_es_cluster()
-
-def set_default_es_cluster():
-        global ES_CLUSTER
-        json = fetch_url("http://" + ES_HOST + ":" + str(ES_PORT))
-        if json:
-                ES_CLUSTER = json["cluster_name"]
-        else:
-                ES_CLUSTER = "elasticsearch"
-
+ES_CLUSTER = "elasticsearch" 
 
 ENABLE_INDEX_STATS = True
 ENABLE_CLUSTER_STATS = True
@@ -731,10 +722,19 @@ class CollectdValuesMock(object):
                 attrs.append("{}={}".format(name, getattr(self, name)))
         return "<CollectdValues {}>".format(' '.join(attrs))
 
+def set_es_cluster_from_host():
+        global ES_CLUSTER
+        json = fetch_url("http://" + ES_HOST + ":" + str(ES_PORT))
+        if json:
+                ES_CLUSTER = json["cluster_name"]
+        else: 
+                ES_CLUSTER = "elasticsearch" 
+                
+
 
 if __name__ == '__main__':
     import sys
-
+    set_es_cluster_from_host()
     collectd = CollectdMock()
     load_es_version()
     init_stats()

--- a/elasticsearch_collectd.py
+++ b/elasticsearch_collectd.py
@@ -19,10 +19,19 @@ import json
 import urllib2
 
 PREFIX = "elasticsearch"
-ES_CLUSTER = "elasticsearch"
 ES_HOST = "localhost"
 ES_PORT = 9200
 ES_VERSION = None
+ES_CLUSTER = set_default_es_cluster()
+
+def set_default_es_cluster():
+        global ES_CLUSTER
+        json = fetch_url("http://" + ES_HOST + ":" + str(ES_PORT))
+        if json:
+                ES_CLUSTER = json["cluster_name"]
+        else:
+                ES_CLUSTER = "elasticsearch"
+
 
 ENABLE_INDEX_STATS = True
 ENABLE_CLUSTER_STATS = True


### PR DESCRIPTION
Instead of having a default name for ES_CLUSTER this change tries to get the cluster name from elastic search running locally.
