### PR TITLE
Collect jvm pool size metrics for young/old

### DIFF
--- a/elasticsearch_collectd.py
+++ b/elasticsearch_collectd.py
@@ -169,6 +169,14 @@ NODE_STATS = {
         Stat("gauge", "nodes.%s.jvm.mem.non_heap_committed_in_bytes"),
     'jvm.mem.non-heap-used': Stat("gauge",
                                   "nodes.%s.jvm.mem.non_heap_used_in_bytes"),
+    'jvm.mem.pools.young.max_in_bytes': Stat("gauge",
+                                  "nodes.%s.jvm.mem.pools.young.max_in_bytes"),
+    'jvm.mem.pools.young.used_in_bytes': Stat("gauge",
+                                  "nodes.%s.jvm.mem.pools.young.used_in_bytes"),
+    'jvm.mem.pools.old.max_in_bytes': Stat("gauge",
+                                  "nodes.%s.jvm.mem.pools.old.max_in_bytes"),
+    'jvm.mem.pools.old.used_in_bytes': Stat("gauge",
+                                  "nodes.%s.jvm.mem.pools.old.used_in_bytes"),
 
     # UPTIME
     'jvm.uptime': Stat("counter", "nodes.%s.jvm.uptime_in_millis"),


### PR DESCRIPTION
This change has been tested on es 1.4.4-1 for both CMS and G1GC.
The max values are useless for g1gc, but that's to be expected.

/cc @JDShu these values should cover our needs for monitoring tenured size
