### PR TITLE
Collect es2 query cache metrics (the new filter cache)

### DIFF
--- a/elasticsearch_collectd.py
+++ b/elasticsearch_collectd.py
@@ -196,6 +196,18 @@ NODE_STATS = {
     'process.cpu.percent': Stat("gauge", "nodes.%s.process.cpu.percent"),
 }
 
+# DICT: ElasticSearch 2.2.x
+NODE_STATS_ES_2_2 = {
+    'indices.cache.query-cache.evictions':
+        Stat("counter", "nodes.%s.indices.query_cache.evictions"),
+    'indices.cache.query-cache.size':
+        Stat("gauge", "nodes.%s.indices.query_cache.memory_size_in_bytes"),
+    'indices.cache.query-cache.hits':
+        Stat("counter", "nodes.%s.indices.query_cache.hit_count"),
+    'indices.cache.query-cache.total':
+        Stat("counter", "nodes.%s.indices.query_cache.total_count"),
+}
+
 # ElasticSearch 1.3.0
 INDEX_STATS_ES_1_3 = {
     # SEGMENTS
@@ -520,6 +532,9 @@ def init_stats():
                   "/_nodes/_local/stats/transport,http,process,jvm,indices," \
                   "thread_pool"
     NODE_STATS_CUR = dict(NODE_STATS.items())
+    if ES_VERSION.startswith("2.2"):
+      NODE_STATS_CUR.update(NODE_STATS_ES_2_2)
+
     INDEX_STATS_CUR = dict(INDEX_STATS.items())
     if ES_VERSION.startswith("1.1") or ES_VERSION.startswith("1.2"):
         INDEX_STATS_CUR.update(INDEX_STATS_ES_1_1)


### PR DESCRIPTION
ES2 changed up the filter cache a bit. This PR collects a select portion of the new metrics. I've run this against a 1.4.4 cluster to verify the metrics are not sent, as well as a 2.2.0 cluster to verify the metrics are sent.

/cc @JDShu
