### PR TITLE
Turn off log propagation

### DIFF
--- a/elasticsearch_collectd.py
+++ b/elasticsearch_collectd.py
@@ -1130,6 +1130,7 @@ class CollectdLogger(logging.Logger):
 logging.setLoggerClass(CollectdLogger)
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
+log.propagate = False
 handle = CollectdLogHandler(PREFIX)
 log.addHandler(handle)
 


### PR DESCRIPTION
Turn off in order to stop additional logging to syslog
