### PR TITLE
Restore compatibility with python 2.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,18 @@
 
 This file documents important changes to the Elasticsearch plugin for collectd. 
 
+- [2016-08-08: Restore compatibility with 
+python v2.6](#2016-08-08)
 - [2016-07-21: Dimensionalize thread pool metrics
 by thread pool](#2016-07-21-dimensionalize-thread-pool-metrics-by-thread-pool)
 - [2016-06-28: Basic configuration
 changes](#2016-06-28-changes-to-basic-plugin-configuration) 
 - [2016-06-27: Support for basic 
 authentication](#2016-06-27-support-for-basic-authentication)
+
+#### <a id="2016-08-08"></a> 2016-08-08: Restore compatibility with python v2.6 
+
+This latest revision restores compatibility with Python v2.6.
 
 #### 2016-07-21: Dimensionalize thread pool metrics by thread pool
 

--- a/elasticsearch_collectd.py
+++ b/elasticsearch_collectd.py
@@ -57,7 +57,7 @@ DETAILED_METRICS = True
 THREAD_POOLS = []
 CONFIGURED_THREAD_POOLS = set()
 
-DEFAULTS = {
+DEFAULTS = set([
     # AUTOMATICALLY GENERATED METRIC NAMES
     # TO INCLUDE BY DEFAULT
     "indices.total.docs.deleted",
@@ -96,16 +96,16 @@ DEFAULTS = {
     "thread_pool.rejected",
     "jvm.uptime",
     "indices.total.filter-cache.memory-size",
-}
+])
 
-DEFAULTS.update({
+DEFAULTS.update([
     # ADD ADDITIONAL METRIC NAMES
     # TO INCLUDE BY DEFAULT
     "cluster.status",
     "indices.indexing.index-time",
-    "indices.merges.time"
+    "indices.merges.time",
     "indices.store.throttle-time",
-})
+])
 
 # DICT: ElasticSearch 1.0.0
 NODE_STATS = {
@@ -1017,19 +1017,19 @@ class CollectdMock(object):
         self.value_mock = CollectdValuesMock
 
     def debug(self, msg):
-        print 'DEBUG: {}'.format(msg)
+        print 'DEBUG: {0}'.format(msg)
 
     def info(self, msg):
-        print 'INFO: {}'.format(msg)
+        print 'INFO: {0}'.format(msg)
 
     def notice(self, msg):
-        print 'NOTICE: {}'.format(msg)
+        print 'NOTICE: {0}'.format(msg)
 
     def warning(self, msg):
-        print 'WARN: {}'.format(msg)
+        print 'WARN: {0}'.format(msg)
 
     def error(self, msg):
-        print 'ERROR: {}'.format(msg)
+        print 'ERROR: {0}'.format(msg)
         sys.exit(1)
 
     def Values(self, plugin='elasticsearch'):
@@ -1044,8 +1044,8 @@ class CollectdValuesMock(object):
         attrs = []
         for name in dir(self):
             if not name.startswith('_') and name is not 'dispatch':
-                attrs.append("{}={}".format(name, getattr(self, name)))
-        return "<CollectdValues {}>".format(' '.join(attrs))
+                attrs.append("{0}={1}".format(name, getattr(self, name)))
+        return "<CollectdValues {0}>".format(' '.join(attrs))
 
 
 class CollectdLogHandler(logging.Handler):
@@ -1061,7 +1061,7 @@ class CollectdLogHandler(logging.Handler):
         plugin -- name of the plugin (default 'unknown')
         verbose -- enable/disable verbose messages (default False)
     """
-    def __init__(self, plugin="unknown", verbose=False):
+    def __init__(self, plugin="elasticsearch", verbose=False):
         """Initializes CollectdLogHandler
         Arguments
             plugin -- string name of the plugin (default 'unknown')
@@ -1147,7 +1147,7 @@ def configure_test():
                                    'refresh', 'suggest', 'percolate',
                                    'management', 'listener',
                                    'fetch_shard_store', 'fetch_shard_started',
-                                   'force_merge', 'merge', 'optimize'])
+                                   'force_merge', 'merge', 'optimize', ])
     DETAILED_METRICS = True
     INDEX_INTERVAL = 10
     ENABLE_INDEX_STATS = True

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,12 +1,21 @@
 #!/bin/bash
+PYTHON="python"
+if [ ! -z "$1" ]; then
+  PYTHON="$1"
+fi
+
+PYTHON_VERSION=$(${PYTHON} -V 2>&1)
+
+echo "Interpreter version: ${PYTHON_VERSION}"
+
 tmpfile=$(mktemp /tmp/run_tests.sh.XXXXXX)
 trap 'rm -f $tmpfile' 1 2 3 15
 for scenario in `ls data`; do
   echo -n "testing against ES $scenario"
 
-  ./simulate.py data/${scenario} &> /dev/null &
+  ${PYTHON} ./simulate.py data/${scenario} &> /dev/null &
   pid="$!"
-  ../elasticsearch_collectd.py > $tmpfile
+  ${PYTHON} ../elasticsearch_collectd.py > $tmpfile
   if [ $? != 0 ]; then
     echo " [FAILED] returned non 0 exit code"
   else


### PR DESCRIPTION
Convert python 2.7 set notation with set()
Convert empty string format specifiers with numeric specifiers
