### PR TITLE
Make Cluster config option required

### DIFF
--- a/elasticsearch_collectd.py
+++ b/elasticsearch_collectd.py
@@ -979,14 +979,6 @@ class Cluster(object):
         json = self.fetch_url(self.es_url_scheme + "://" + self.es_host + ":" +
                               str(self.es_port) + "/_nodes/_local")
         if json is None:
-            # assume some sane defaults
-            if self.es_version is None:
-                self.es_version = "1.0.0"
-            self.es_master_eligible = True
-            log.warning('Unable to determine node information, defaulting to \
-                        version %s, cluster %s and master %s' %
-                        (self.es_version, self.es_cluster,
-                         self.es_master_eligible))
             return
 
         # Identify the current node
@@ -1104,6 +1096,13 @@ class Cluster(object):
                             'and no Cluster config option specified. ' +
                             'Will not emit datapoints since plugin_instance ' +
                             'which is the cluster name could not be determined')
+            return
+
+        if self.es_version is None:
+            log.warning('Failed to determine ES version in read_callback. ' +
+                            'Will not emit datapoints since plugin_instance ' +
+                            'this interval. Will attempt to fetch version in the ' +
+                            'next interval.')
             return
         estype = key.type
         value = int(result)

--- a/elasticsearch_collectd.py
+++ b/elasticsearch_collectd.py
@@ -974,8 +974,6 @@ class Cluster(object):
             # assume some sane defaults
             if self.es_version is None:
                 self.es_version = "1.0.0"
-            if self.es_cluster is None:
-                self.es_cluster = "elasticsearch"
             self.es_master_eligible = True
             log.warning('Unable to determine node information, defaulting to \
                         version %s, cluster %s and master %s' %
@@ -1092,6 +1090,15 @@ class Cluster(object):
                                                              r=result))
         if result is None:
             log.warning('Value not found for %s' % name)
+            return
+
+        # If we failed to get the cluster name and do not have a config
+        # option set for it, do not emit data
+        if self.es_cluster is None:
+            log.warning('Failed to determine Cluster name in read_callback' +
+                            'and no Cluster config option specified. ' +
+                            'Will not emit datapoints since plugin_instance ' +
+                            'which is the cluster name could not be determined')
             return
         estype = key.type
         value = int(result)

--- a/elasticsearch_collectd.py
+++ b/elasticsearch_collectd.py
@@ -686,11 +686,19 @@ def configure_callback(conf):
     # register the read callback now that we have the complete config
     collectd.register_read(read_callback,
                            interval=c.collection_interval,
-                           name=c.es_cluster,
+                           name=get_unique_name(c.es_host,
+                                            c.es_port, c.es_index),
                            data=c)
     log.notice(
         'started elasticsearch plugin with interval = %d seconds' %
         c.collection_interval)
+
+
+def get_unique_name(host, port, index):
+    if index:
+        return ('%s:%s:%s' % (host, port, index))
+    else:
+        return ('%s:%s' % (host, port))
 
 
 def remove_deprecated_elements(deprecated, elements, version):

--- a/elasticsearch_collectd.py
+++ b/elasticsearch_collectd.py
@@ -993,7 +993,6 @@ class Cluster(object):
         self.node_id = json['nodes'].keys()[0]
         log.notice('current node id: %s' % self.node_id)
 
-        cluster_name = json['cluster_name']
         # we should have only one entry with the current node information
         node_info = json['nodes'].itervalues().next()
         version = node_info['version']
@@ -1011,8 +1010,6 @@ class Cluster(object):
         self.es_master_eligible = master_eligible
         if self.es_version is None:
             self.es_version = version
-        if self.es_cluster is None:
-            self.es_cluster = cluster_name
 
         log.notice('version: %s, cluster: %s, master eligible: %s' %
                    (self.es_version, self.es_cluster, self.es_master_eligible))

--- a/elasticsearch_collectd.py
+++ b/elasticsearch_collectd.py
@@ -911,15 +911,10 @@ class Cluster(object):
             # Only if Cluster name is not provided as a config option, use the
             # value retured from the ES endpoint
             if self.es_cluster_from_config is None:
-                es_cluster_from_endpoint = node_json_stats['cluster_name']
-                # Check if cluster name matches from what the plugin saw in the
-                # previous interval, in not, update the cluster name
-                if es_cluster_from_endpoint != self.es_cluster:
-                    self.es_cluster = es_cluster_from_endpoint
+                self.es_cluster = node_json_stats['cluster_name']
             else:
                 self.es_cluster = self.es_cluster_from_config
-                log.info('Configured with cluster_json_stats=%s' %
-                         self.es_cluster)
+            log.info('Configured with cluster_name=%s' % self.es_cluster)
             log.info('Parsing node_json_stats')
             self.parse_node_stats(node_json_stats, self.node_stats_cur)
             log.info('Parsing thread pool stats')
@@ -1008,10 +1003,7 @@ class Cluster(object):
 
         # update settings
         self.es_master_eligible = master_eligible
-        # Update version if it is different from the version seen in the
-        # previous interval
-        if self.es_version != version:
-            self.es_version = version
+        self.es_version = version
 
         log.notice('version: %s, cluster: %s, master eligible: %s' %
                    (self.es_version, self.es_cluster, self.es_master_eligible))

--- a/tests/integration/20-elasticsearch-test.conf
+++ b/tests/integration/20-elasticsearch-test.conf
@@ -25,4 +25,10 @@
         IndexInterval 3
         Host es53
     </Module>
+
+    <Module "elasticsearch_collectd">
+        Interval 3
+        IndexInterval 3
+        Host es56
+    </Module>
 </Plugin>

--- a/tests/integration/Dockerfile.es.5.6.3
+++ b/tests/integration/Dockerfile.es.5.6.3
@@ -1,0 +1,5 @@
+FROM elasticsearch:5.6.3
+
+CMD /set_cluster_name
+
+ADD set_cluster_name /set_cluster_name

--- a/tests/integration/docker-compose.yml
+++ b/tests/integration/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - es17
       - es24
       - es53
+      - es56
 
   es17:
     build:
@@ -28,6 +29,11 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.es.5.3.2
+
+  es56:
+    build:
+      context: .
+      dockerfile: Dockerfile.es.5.6.3
 
   fake_sfx:
     build:

--- a/tests/integration/test.py
+++ b/tests/integration/test.py
@@ -15,6 +15,7 @@ VERSIONS_TESTED = [
     '1.7.6',
     '2.4.5',
     '5.3.2',
+    '5.6.3',
 ]
 TIMEOUT_SECS = 60
 

--- a/tests/integration/wait_for_es
+++ b/tests/integration/wait_for_es
@@ -8,7 +8,7 @@ wait_for () {
     done
 }
 
-for host in es17 es24 es53
+for host in es17 es24 es53 es56
 do
   wait_for $host
 done


### PR DESCRIPTION
We use the Cluster name for determining `plugin_instance`. So we need to be able to reliably put in the value a customer expects. The way we currently do within the `configure_callback` method, we default to `elasticsearch` for the cluster name if it's not available for whatever reason from the ES endpoint. At a later point if collectd is restarted and the value from the ES endpoint is available, the plugin breaks the previous MTSs because it'll send datapoints with the "new" cluster name as the `plugin_instance`. Determining this through the config will help avoid the issue.

Apart from making the Cluster option required, this PR also updates the way configs are passed to the read_callback method - pass the info as a parameter while registering the read_callback method instead of using global variables. 