### PR TITLE
Do not dispatch 0 value for non existent stats

### DIFF
--- a/elasticsearch_collectd.py
+++ b/elasticsearch_collectd.py
@@ -948,13 +948,7 @@ class Cluster(object):
     def lookup_node_stat(self, stat, json):
         node = json['nodes'].keys()[0]
         val = dig_it_up(json, self.node_stats_cur[stat].path % node)
-
-        # Check to make sure we have a valid result
-        # dig_it_up returns False if no match found
-        if not isinstance(val, bool):
-            return int(val)
-        else:
-            return None
+        return val
 
     def fetch_stats(self):
         """
@@ -1104,12 +1098,6 @@ class Cluster(object):
                     if self.detailed_metrics is True or name in self.defaults:
                         node = json['nodes'].keys()[0]
                         result = dig_it_up(json, key.path % node)
-                        # Check to make sure we have a valid result
-                        # dig_it_up returns False if no match found
-                        if not isinstance(result, bool):
-                            result = int(result)
-                        else:
-                            result = None
 
                         self.dispatch_stat(result, name, key,
                                            {'thread_pool': pool})
@@ -1144,7 +1132,7 @@ class Cluster(object):
                                                              d=dimensions,
                                                              r=result))
         if result is None:
-            log.warning('Value not found for %s' % name)
+            log.debug('Value not found for %s' % name)
             return
 
         # If we failed to get the cluster name and do not have a config
@@ -1210,7 +1198,7 @@ def dig_it_up(obj, path):
             path = path.split('.')
         return reduce(lambda x, y: x[y], path, obj)
     except:
-        return False
+        return None
 
 
 # The following classes are there to launch the plugin manually


### PR DESCRIPTION
Issue: `dig_it_up` returns `False` if a path does not exist in a json passed along with it. Wherever `dig_it_up` is called, there should be a subsequent check to determine whether the value returned is a bool or not and handle it accordingly. For index and cluster stats this check was not in place and as a result the plugin sends in 0 if a stat does not exist. This is because we cast these values to `int` in the `dispatch_stat` method. 

Updates in this PR:

- Make `dig_it_up` return None if a path is not found in a json
- Let `dispatch_stat` do the casting to int