### PR TITLE
Restore legacy support for old configurations without Thread Pools config

### DIFF
--- a/elasticsearch_collectd.py
+++ b/elasticsearch_collectd.py
@@ -727,7 +727,7 @@ class Cluster(object):
 
         # Legacy support for old configurations without Thread Pools config
         if len(self.configured_thread_pools) == 0:
-            self.thread_pools = list(self.configured_thread_pools)
+            self.thread_pools = thread_pools
         else:
             # Filter out the thread pools that aren't specified by user
             self.thread_pools = [pool for pool in thread_pools if pool in self.configured_thread_pools]


### PR DESCRIPTION
According to the code comment, the legacy behaviour when explicit Thread Pools are missing is to use the default list, built based on Elasticsearch version.

This should also fix #53. I couldn't find the documentation mentioned in this issue though.